### PR TITLE
fix: possible fix for missing memories in production

### DIFF
--- a/apps/frontend/src/modules/home/pages/memory-form-page.jsx
+++ b/apps/frontend/src/modules/home/pages/memory-form-page.jsx
@@ -116,7 +116,7 @@ function MemoryFormPage() {
       setMemories(updatedMemories);
 
       // small delay before refetching from backend
-      await new Promise(resolve => setTimeout(resolve, 500));
+      await new Promise((resolve) => setTimeout(resolve, 500));
       await fetchMemories();
 
       // Reset form


### PR DESCRIPTION
- updated backend URL variable and added .catch() for the error handling
